### PR TITLE
INFOSEC-711: Added .gitallowed

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -1,0 +1,2 @@
+\.gitallowed:.*
+^.*REPOPASSWORD.*$


### PR DESCRIPTION
Added `.gitallowed` file in order to suppress false positives in the InfoSec secrets scanner.

---

Ticket: https://issues.appian.com/browse/INFOSEC-711